### PR TITLE
pango: prefer 'malgun gothic' before 'gulimche'

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -1631,6 +1631,7 @@ class Project_pango(Tarball, Meson):
                 '002-win32-load-aliases.patch',
                 '003-win32-font-corruption.patch',
                 '004-win32-thread-corruption.patch',
+                '005-win32-pango-aliases.patch',
             ],
             )
         if self.opts.enable_gi:

--- a/patches/pango/005-win32-pango-aliases.patch
+++ b/patches/pango/005-win32-pango-aliases.patch
@@ -1,0 +1,29 @@
+diff -bru a/pango/pangowin32-fontmap.c b/pango/pangowin32-fontmap.c
+--- a/pango/pangowin32-fontmap.c	2019-10-25 12:45:11.000000000 +0900
++++ b/pango/pangowin32-fontmap.c	2021-09-02 16:18:50.550499600 +0900
+@@ -454,11 +454,11 @@
+    * has ony one. One solution is to install the free DejaVu fonts
+    * that are popular on Linux. They are listed here first.
+    */
+-  "sans = \"dejavu sans,tahoma,arial unicode ms,lucida sans unicode,browallia new,mingliu,simhei,gulimche,ms gothic,sylfaen,kartika,latha,mangal,raavi\"",
+-  "sans-serif = \"dejavu sans,tahoma,arial unicode ms,lucida sans unicode,browallia new,mingliu,simhei,gulimche,ms gothic,sylfaen,kartika,latha,mangal,raavi\"",
+-  "serif = \"dejavu serif,georgia,angsana new,mingliu,simsun,gulimche,ms gothic,sylfaen,kartika,latha,mangal,raavi\"",
+- "mono = \"dejavu sans mono,courier new,lucida console,courier monothai,mingliu,simsun,gulimche,ms gothic,sylfaen,kartika,latha,mangal,raavi\"",
+-  "monospace = \"dejavu sans mono,courier new,lucida console,courier monothai,mingliu,simsun,gulimche,ms gothic,sylfaen,kartika,latha,mangal,raavi\"",
++  "sans = \"dejavu sans,tahoma,arial unicode ms,lucida sans unicode,browallia new,mingliu,simhei,malgun gothic,gulimche,ms gothic,sylfaen,kartika,latha,mangal,raavi\"",
++  "sans-serif = \"dejavu sans,tahoma,arial unicode ms,lucida sans unicode,browallia new,mingliu,simhei,malgun gothic,gulimche,ms gothic,sylfaen,kartika,latha,mangal,raavi\"",
++  "serif = \"dejavu serif,georgia,angsana new,mingliu,simsun,malgun gothic,gulimche,ms gothic,sylfaen,kartika,latha,mangal,raavi\"",
++ "mono = \"dejavu sans mono,courier new,lucida console,courier monothai,mingliu,simsun,malgun gothic,gulimche,ms gothic,sylfaen,kartika,latha,mangal,raavi\"",
++  "monospace = \"dejavu sans mono,courier new,lucida console,courier monothai,mingliu,simsun,malgun gothic,gulimche,ms gothic,sylfaen,kartika,latha,mangal,raavi\"",
+   "emoji = \"segoe ui emoji,segoe ui symbol,segoe ui\"",
+   "cursive = \"commic sans ms\"",
+   "fantasy = \"gabriola,impact\"",
+@@ -583,7 +583,7 @@
+        * but I couldn't find any docs for it. Feel free to improve this */
+       g_string_append (line_buffer,
+                        ",gisha,leelawadee,arial unicode ms,browallia new,"
+-                       "mingliu,simhei,gulimche,ms gothic,sylfaen,kartika,"
++                       "mingliu,simhei,malgun gothic,gulimche,ms gothic,sylfaen,kartika,"
+                        "latha,mangal,raavi");
+ 
+       g_string_append (line_buffer, "\"");


### PR DESCRIPTION
최신버전 pango 1.44.7 버전은 'etc/pango.aliases'파일을 사용하지 않고 소스코드에서 폰트 aliase를 설정합니다. 굴림체 앞에 맑은 고딕을 사용하도록 합니다.  어두운 테마(Dark Theme) 지원 (nvrsw/dooly#1242)