### PR TITLE
gdk-pixbuf: support image file format in windows

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -405,6 +405,7 @@ class Project_gdk_pixbuf(Tarball, Meson):
                 'glib',
                 'libpng',
             ],
+            patches = ['001-enable-native-windows-loader.patch'],
             )
         if self.opts.enable_gi:
             self.add_dependency('gobject-introspection')

--- a/patches/gdk-pixbuf/001-enable-native-windows-loader.patch
+++ b/patches/gdk-pixbuf/001-enable-native-windows-loader.patch
@@ -1,0 +1,12 @@
+diff -bru a/meson_options.txt b/meson_options.txt
+--- a/meson_options.txt	2019-10-08 19:44:10.000000000 +0900
++++ b/meson_options.txt	2023-12-08 13:17:24.991614300 +0900
+@@ -41,7 +41,7 @@
+ option('native_windows_loaders',
+        description: 'Use Windows system components to handle BMP, EMF, GIF, ICO, JPEG, TIFF and WMF images, overriding jpeg and tiff.  To build this into gdk-pixbuf, pass in windows" with the other loaders to build in or use "all" with the builtin_loaders option',
+        type: 'boolean',
+-       value: false)
++       value: true)
+ option('installed_tests',
+        description: 'Install the test suite',
+        type: 'boolean',


### PR DESCRIPTION
윈도우에서 gdk-pixbuf에서 JPEG 이미지 파일 포맷을 지원하지 않는 문제를 수정합니다. ( 윈도우 VMS 매니저 맵 배경 화면 표시 안 됨 nvrsw/heedong#320)