### PR TITLE
clutter: do not call clutter_text_set_buffer() on finalize

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -107,7 +107,7 @@ class Project_clutter(Tarball, Project):
             archive_url = 'http://ftp.acc.umu.se/pub/GNOME/sources/clutter/1.26/clutter-1.26.4.tar.xz',
             hash = '8b48fac159843f556d0a6be3dbfc6b083fc6d9c58a20a49a6b4919ab4263c4e6',
             dependencies = ['atk','cogl','json-glib'],
-            patches = ['001-input-method-editor.patch', '002-void-return-error.patch'],
+            patches = ['001-input-method-editor.patch', '002-void-return-error.patch', '003-clutter-text-freeze-notification.patch'],
             )
 
     def build(self):

--- a/patches/clutter/003-clutter-text-freeze-notification.patch
+++ b/patches/clutter/003-clutter-text-freeze-notification.patch
@@ -1,0 +1,26 @@
+diff --git a/clutter/clutter-text.c b/clutter/clutter-text.c
+index 0b83de9..e52aaab 100644
+--- a/clutter/clutter-text.c
++++ b/clutter/clutter-text.c
+@@ -1475,7 +1475,12 @@ clutter_text_dispose (GObject *gobject)
+       priv->password_hint_id = 0;
+     }
+ 
+-  clutter_text_set_buffer (self, NULL);
++  if (priv->buffer)
++    {
++      buffer_disconnect_signals (self);
++      g_clear_object (&priv->buffer);
++    }
++
+ 
+   G_OBJECT_CLASS (clutter_text_parent_class)->dispose (gobject);
+ }
+@@ -1500,7 +1505,6 @@ clutter_text_finalize (GObject *gobject)
+ 
+   clutter_text_dirty_paint_volume (self);
+ 
+-  clutter_text_set_buffer (self, NULL);
+   g_free (priv->font_name);
+ 
+   G_OBJECT_CLASS (clutter_text_parent_class)->finalize (gobject);

--- a/patches/clutter/003-clutter-text-freeze-notification.patch
+++ b/patches/clutter/003-clutter-text-freeze-notification.patch
@@ -1,22 +1,8 @@
 diff --git a/clutter/clutter-text.c b/clutter/clutter-text.c
-index 0b83de9..e52aaab 100644
+index 0b83de9..3b71b7a 100644
 --- a/clutter/clutter-text.c
 +++ b/clutter/clutter-text.c
-@@ -1475,7 +1475,12 @@ clutter_text_dispose (GObject *gobject)
-       priv->password_hint_id = 0;
-     }
- 
--  clutter_text_set_buffer (self, NULL);
-+  if (priv->buffer)
-+    {
-+      buffer_disconnect_signals (self);
-+      g_clear_object (&priv->buffer);
-+    }
-+
- 
-   G_OBJECT_CLASS (clutter_text_parent_class)->dispose (gobject);
- }
-@@ -1500,7 +1505,6 @@ clutter_text_finalize (GObject *gobject)
+@@ -1500,7 +1500,6 @@ clutter_text_finalize (GObject *gobject)
  
    clutter_text_dirty_paint_volume (self);
  


### PR DESCRIPTION
glib 2.75.2 버전 이상에서 아래 에러 메세지가 발생하는 문제를 수정합니다. (렌더링 엔진 개선 https://github.com/nvrsw/dooly/issues/2384 )

>   ```
>   2024-12-20 13:43:34 [E] Attempting to freeze the notification queue for object ClutterText[000000000E905210]; Property notification does not work during instance finalization.
>   2024-12-20 13:43:34 [E] Attempting to thaw the notification queue for object ClutterText[000000000E905210]; Property notification does not work during instance finalization.
>   2024-12-20 13:43:34 [E] Attempting to freeze the notification queue for object ClutterText[000000000EA43F50]; Property notification does not work during instance finalization.
>   2024-12-20 13:43:34 [E] Attempting to thaw the notification queue for object ClutterText[000000000EA43F50]; Property notification does not work during instance finalization.
>   ```


- https://gitlab.gnome.org/GNOME/mutter/-/issues/2566
- [clutter/text: Don't call clutter_text_set_buffer() on finalize](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2790)
- https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2790/diffs?commit_id=cff631cb39b1b9d66b791fb51a6f2c3db8e60917
