### PR TITLE
gdk-pixbuf: apply pathch to support image file format

### DIFF
--- a/gvsbuild/projects.py
+++ b/gvsbuild/projects.py
@@ -420,6 +420,7 @@ class Project_gdk_pixbuf(Tarball, Meson):
                 "glib",
                 "libpng",
             ],
+            patches = ['001-enable-native-windows-loader.patch'],
             )
         if self.opts.enable_gi:
             self.add_dependency("gobject-introspection")

--- a/patches/gdk-pixbuf/001-enable-native-windows-loader.patch
+++ b/patches/gdk-pixbuf/001-enable-native-windows-loader.patch
@@ -1,0 +1,22 @@
+diff --git a/meson_options.txt b/meson_options.txt
+index 7483015..2e71113 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -22,7 +22,7 @@ option('builtin_loaders',
+        description: 'Comma-separated list of loaders to build into gdk-pixbuf',
+        type: 'array',
+        choices: ['all', 'none', 'windows', 'png', 'bmp', 'gif', 'ico', 'ani', 'jpeg', 'pnm', 'tiff', 'xpm', 'xbm', 'tga', 'icns', 'qtif'],
+-       value: ['png', 'jpeg'])
++       value: ['all'])
+ option('gtk_doc',
+        description: 'Whether to generate the API reference',
+        type: 'boolean',
+@@ -48,7 +48,7 @@ option('relocatable',
+ option('native_windows_loaders',
+        description: 'Use Windows system components to handle BMP, EMF, GIF, ICO, JPEG, TIFF and WMF images, overriding jpeg and tiff.  To build this into gdk-pixbuf, pass in windows" with the other loaders to build in or use "all" with the builtin_loaders option',
+        type: 'boolean',
+-       value: false)
++       value: true)
+ option('tests',
+        description: 'Build the test suite',
+        type: 'boolean',


### PR DESCRIPTION
윈도우에서 `png`, `jpeg`외에 다른 그림 파일 로드가 실패하는 문제를 수정합니다. 커밋을 리버트할려 했으나 버전이 맞지 않아 현재 적용된 gdk-pixbuf-2.42.12 버전에 맞게 패치를 새롭게 적용하도록 합니다. (비디오 월 비트맵(BMP) 그림 전송 안 됨 nvrsw/dooly#2641)